### PR TITLE
Fix parsing of message 0x4067

### DIFF
--- a/pysamsungnasa/protocol/enum.py
+++ b/pysamsungnasa/protocol/enum.py
@@ -1370,11 +1370,11 @@ class InTdmIndoorType(SamsungEnum, IntEnum):
     """Air-to-water TDM type"""
 
 
-class In3WayValve2(SamsungEnum, IntEnum):
+class In3WayValve(SamsungEnum, IntEnum):
     """
-    3-Way Valve 2 state (Message 0x4113).
-    Label (NASA.prc): ENUM_IN_3WAY_VALVE_2
-    XML ProtocolID: ENUM_IN_3WAY_VALVE_2
+    3-Way Valve state (Message 0x4067/0x4113).
+    Label (NASA.prc): ENUM_IN_3WAY_VALVE
+    XML ProtocolID: ENUM_IN_3WAY_VALVE
     """
 
     ROOM = 0
@@ -2171,18 +2171,6 @@ class InLouverVlPos(SamsungEnum, IntEnum):
     FULL_CLOSE = 0
     PARTIAL_OPEN = 1
     FULL_OPEN = 2
-
-
-class InThermostatMode(SamsungEnum, IntEnum):
-    """
-    Indoor unit thermostat mode (Message 0x4067).
-    Label (NASA.prc): ENUM_IN_THERMOSTAT_MODE
-    """
-
-    OFF = 0
-    """Thermostat mode is off"""
-    ON = 1
-    """Thermostat mode is on"""
 
 
 class InSolarPump(SamsungEnum, IntEnum):

--- a/pysamsungnasa/protocol/factory/messages/indoor.py
+++ b/pysamsungnasa/protocol/factory/messages/indoor.py
@@ -63,7 +63,6 @@ from ...enum import (
     InLouverHlDownUp,
     InLouverHlNowPos,
     InLouverVlPos,
-    InThermostatMode,
     InSolarPump,
     InThermostat0,
     InOutingMode,
@@ -95,7 +94,7 @@ from ...enum import (
     InFsv5091,
     InFsv5094,
     InZone2Power,
-    In3WayValve2,
+    In3WayValve,
     InPvContactState,
     InSgReadyModeState,
 )
@@ -434,12 +433,12 @@ class InDhwOpMode(EnumMessage):
     MESSAGE_ENUM = DhwOpMode
 
 
-class InThermostatModeMessage(EnumMessage):
-    """Parser for message 0x4067 (Indoor Thermostat Mode)."""
+class In3WayValveMessage(EnumMessage):
+    """Parser for message 0x4067 (3-Way Valve control)."""
 
     MESSAGE_ID = 0x4067
-    MESSAGE_NAME = "Indoor Thermostat Mode"
-    MESSAGE_ENUM = InThermostatMode
+    MESSAGE_NAME = "3-Way Valve control"
+    MESSAGE_ENUM = In3WayValve
 
 
 class InSolarPumpMessage(EnumMessage):
@@ -451,7 +450,7 @@ class InSolarPumpMessage(EnumMessage):
 
 
 class InThermostatZone1Status(EnumMessage):
-    """Parser for message 0x4067 (Indoor Thermostat Zone 1 Status)."""
+    """Parser for message 0x4069 (Indoor Thermostat Zone 1 Status)."""
 
     MESSAGE_ID = 0x4069
     MESSAGE_NAME = "Indoor Thermostat Zone 1 Status"
@@ -906,7 +905,7 @@ class In3WayValve2Message(EnumMessage):
 
     MESSAGE_ID = 0x4113
     MESSAGE_NAME = "3-Way Valve 2 control"
-    MESSAGE_ENUM = In3WayValve2
+    MESSAGE_ENUM = In3WayValve
 
 
 class InEnumUnknown4117Message(RawMessage):


### PR DESCRIPTION
Update the parsing logic and class definitions related to the 3-Way Valve to correctly reflect the message 0x4067. This includes renaming classes and adjusting references to ensure accurate message handling.