### PR TITLE
[WIP] Add Smart Grid Control documentation and improve clarity

### DIFF
--- a/docs/protocol/messages-reference.md
+++ b/docs/protocol/messages-reference.md
@@ -301,11 +301,11 @@ Below is a comprehensive reference of NASA message numbers extracted from NASA.p
 
 | Hex | NASA.ptc Label | Description | Type | Values |
 |-----|---|---|---|---|
-| **0x4124** | **ENUM_IN_SG_READY_MODE_STATE** | **SG Ready Mode State - Controls Smart Grid operation mode** | **Enum** | **1=Forced Off, 2=Normal, 3=Load Increase, 4=Load Decrease** |
+| **0x4124** | **ENUM_IN_SG_READY_MODE_STATE** | **Enables or disables the Smart Grid Ready feature** | **Enum** | **0=Off, 1=On** |
 
-**SG Ready Mode State Details:**
+**Smart Grid Operation Modes (Terminal Control):**
 
-This message controls which Smart Grid operation mode the system should enter when FSV #5091 is enabled (set to 1). Each value corresponds to a terminal configuration or external signal:
+When Smart Grid is enabled (via `0x4124` set to 1), the system's operation mode is determined by the state of two physical terminals, not by this message. The modes are as follows:
 
 | **Value** | **Hex** | **Mode Name** | **Terminal 1** | **Terminal 2** | **Behavior** |
 |---|---|---|---|---|---|

--- a/docs/user-guide/smart-grid-control.md
+++ b/docs/user-guide/smart-grid-control.md
@@ -1,0 +1,423 @@
+# Smart Grid Control
+
+Enable your heat pump to participate in grid demand response programs and optimize energy consumption based on grid signals.
+
+## Overview
+
+Smart Grid Control (FSV #5091) allows Samsung heat pumps to respond to external signals from utility companies or grid aggregators. The system can:
+
+- **Reduce heating/DHW capacity** during peak demand periods (load shedding)
+- **Increase heating/DHW** during off-peak hours (load shifting)
+- **Adjust compressor speed** for frequency regulation
+- **Support renewable energy** by shifting loads to high-generation periods
+
+This leads to:
+- Lower energy costs through automated off-peak consumption
+- Reduced demand charges from the utility
+- Grid stability support and renewable integration
+- Energy savings of 10-15% in typical demand response scenarios
+
+## Architecture
+
+Smart Grid Control operates through four distinct operating modes, controlled via two physical terminals or Modbus messages:
+
+| **Mode** | **Terminal 1** | **Terminal 2** | **Behavior** | **Enum Name** |
+|----------|---|---|---|---|
+| **1: Emergency Shutdown** | Short (0V) | Open | All system components stop (thermostat off) | `EMERGENCY_SHUTDOWN` |
+| **2: Normal** | Open | Open | System operates normally with user setpoints | `NORMAL` |
+| **3: Load Increase** | Open | Short (0V) | Temperature setpoints raised (+FSV #5092, +FSV #5093) | `BOOST` |
+| **4: Load Reduction** | Short (0V) | Short (0V) | Temperature adjusted per FSV #5094 settings | `LOAD_REDUCTION` |
+
+## Configuration
+
+### Enable Smart Grid Control
+
+First, enable the feature via FSV #5091:
+
+```python
+# FSV #5091 = 1 to enable Smart Grid Control
+# This allows the system to receive and respond to external signals
+```
+
+### Related Settings
+
+Once enabled, configure the system's response behavior using:
+
+| **FSV** | **Message ID** | **Purpose** | **Default** | **Range** |
+|---------|---|---|---|---|
+| **#5092** | `0x42DD` | Heating temperature shift during Mode 3/4 | 2°C | 2-5°C (0.5°C steps) |
+| **#5093** | `0x42DE` | DHW temperature shift during Mode 3 | 5°C | 2-5°C (0.5°C steps) |
+| **#5094** | `0x411D` | DHW priority during Mode 4 (demand response) | 0 (Comfort) | 0-1 |
+
+### Control Methods
+
+#### Physical Terminal Control
+
+Connect your grid signal controller to the two terminals:
+- Relay outputs or open-collector circuits
+- Short (0V) = terminal active, Open = terminal inactive
+- Switch between modes by energizing different terminal combinations
+
+#### Software Control
+
+Send NASA messages to specify operation modes using the `write_attribute()` method (recommended).
+
+**Message ID**: `0x4124` (SG Ready Mode State)
+
+The SG Ready Mode State message is used to control which operation mode the system enters. Each mode is represented by a specific value:
+
+| **Mode** | **Value** | **Enum Name** | **Behavior** |
+|----------|---|---|---|
+| **1** | `1` | `EMERGENCY_SHUTDOWN` | Forced thermostat off (emergency load shedding) |
+| **2** | `2` | `NORMAL` | Normal operation (user setpoints) |
+| **3** | `3` | `BOOST` | Load increase (pre-heating mode) |
+| **4** | `4` | `LOAD_REDUCTION` | Load decrease (demand response mode) |
+
+```python
+# Recommended approach: Use write_attribute() method for clean, supported API
+from pysamsungnasa.protocol.factory.messages.indoor import InSgReadyModeStateMessage
+from pysamsungnasa.protocol.enum import InSgReadyModeState
+
+# Get your device from SamsungNasa instance
+device = nasa.devices.get("200020")  # Indoor unit 1
+
+# To set Mode 3 (Load Increase/BOOST):
+await device.write_attribute(InSgReadyModeStateMessage, InSgReadyModeState.BOOST)
+
+# To set Mode 1 (emergency load shedding):
+await device.write_attribute(InSgReadyModeStateMessage, InSgReadyModeState.EMERGENCY_SHUTDOWN)
+
+# Other modes:
+await device.write_attribute(InSgReadyModeStateMessage, InSgReadyModeState.NORMAL)
+await device.write_attribute(InSgReadyModeStateMessage, InSgReadyModeState.LOAD_REDUCTION)
+```
+
+**Note**: The `write_attribute()` method is the recommended, supported API for all message sending. This handles message encoding, addressing, and transmission automatically. Avoid calling `to_bytes()` directly - it's internal framework code.
+
+## Operational Scenarios
+
+````
+
+## Operational Scenarios
+
+### Scenario 1: Comfort-Focused Home
+
+Prioritize user comfort, use grid response for heating only:
+
+```python
+# FSV #5091 = 1  (Enable smart grid)
+# FSV #5092 = 2  (Minimal heating shift)
+# FSV #5093 = 5  (Keep DHW stable)
+# FSV #5094 = 0  (Comfort mode: DHW continues regardless of grid signal)
+```
+
+**Response**: During peak demand (Mode 1/`EMERGENCY_SHUTDOWN`), heating stops but DHW continues normally. Users always have hot water.
+
+### Scenario 2: Aggressive Load Shedding
+
+Maximize grid participation, reduce all loads during peak demand:
+
+```python
+# FSV #5091 = 1  (Enable smart grid)
+# FSV #5092 = 5  (Maximum heating reduction)
+# FSV #5093 = 5  (Reduce DHW more aggressively)
+# FSV #5094 = 1  (Demand response mode: DHW stops when signaled)
+```
+
+**Response**: During peak demand (Mode 1/`EMERGENCY_SHUTDOWN`), both heating and DHW stop. All compressor loads shed. Best for areas with tight grid constraints.
+
+### Scenario 3: Time-of-Use Optimization
+
+Shift loads to low-cost hours, pre-heat during abundance periods:
+
+```python
+# FSV #5091 = 1  (Enable smart grid)
+# FSV #5092 = 4  (Moderate heating increase during off-peak)
+# FSV #5093 = 5  (Pre-heat DHW during surplus periods)
+# FSV #5094 = 0  (Maintain comfort)
+```
+
+**Response**: During off-peak (Mode 3/`BOOST`), heating and DHW targets increase. System pre-stores thermal energy to minimize peak-hour operation.
+
+## Message Details
+
+### FSV #5091: Smart Grid Control Application
+
+**Message ID**: `0x411C` | **Type**: Boolean | **Default**: 0 | **Range**: 0-1
+
+Enables/disables the entire smart grid coordination feature.
+
+- **0 (Disabled)**: System operates independently based on user setpoints
+- **1 (Enabled)**: System receives and responds to external control signals
+
+### FSV #5092: Smart Grid Heating Temperature Shift
+
+**Message ID**: `0x42DD` | **Type**: Float | **Unit**: °C | **Default**: 2°C | **Range**: 2-5°C (0.5°C steps)
+
+Temperature increase offset during Smart Grid Mode 3 and 4 (load increase):
+
+- **Mode 3 (BOOST)**: All heating modes (room sensor, outlet, water law) = Current setpoint + FSV #5092
+- **Mode 4 (LOAD_REDUCTION)**: Similar to Mode 3 with additional adjustments for room sensor (+3°C more)
+
+**Typical values**:
+- 2°C - Minimal load increase, less impact on comfort
+- 3°C - Moderate load increase, balanced response
+- 4-5°C - Aggressive load increase, maximizes energy storage
+
+### FSV #5093: Smart Grid DHW Temperature Shift
+
+**Message ID**: `0x42DE` | **Type**: Float | **Unit**: °C | **Default**: 5°C | **Range**: 2-5°C (0.5°C steps)
+
+Temperature increase offset for DHW during Smart Grid Mode 3 (BOOST - load increase):
+
+- **Mode 3 (BOOST)**: DHW setpoint = Current setpoint + FSV #5093
+- **Mode 4 (LOAD_REDUCTION)**: DHW controlled by FSV #5094 instead
+
+**Typical values**:
+- 2°C - Minimal pre-heating, energy savings ~2-3%
+- 3-4°C - Moderate pre-heating, energy savings ~4-8%
+- 5°C - Aggressive pre-heating, maximum energy storage (default)
+
+### FSV #5094: Smart Grid DHW Mode
+
+**Message ID**: `0x411D` | **Type**: Enum | **Default**: 0 | **Range**: 0-1
+
+Controls DHW behavior during Smart Grid Mode 4 (LOAD_REDUCTION - demand response):
+
+- **0 (Comfort Mode)**: DHW heating continues normally, heating may be deferred instead
+  - DHW always available at target temperature
+  - System prioritizes user comfort
+  - Better for residential users
+
+- **1 (Demand Response Mode)**: DHW heating stops/reduces when grid signal active
+  - Maximum demand reduction during peak periods
+  - Tank may cool during extended demand response
+  - Better for grid-sensitive areas, requires backup heating
+
+**Safety Notes**:
+- Even in Mode 1 (demand response), system maintains minimum tank temperature to prevent bacterial growth
+- If equipped with backup electric booster heater, it can provide emergency DHW
+- Does not run indefinitely cold
+
+## Code Examples
+
+### Reading Smart Grid Settings
+
+```python
+from pysamsungnasa import SamsungNasa
+
+async def read_smart_grid_settings():
+    nasa = SamsungNasa(
+        host="192.168.1.100",
+        port=8000,
+        config={"client_address": 1}
+    )
+
+    await nasa.start()
+
+    # Get indoor unit
+    indoor = nasa.devices.get("200020")
+    if not indoor:
+        print("No indoor unit found")
+        return
+
+    # Read smart grid attributes (if available through device)
+    print(f"Device: {indoor.device_type}")
+    print(f"Attributes: {indoor.attributes}")
+
+    # Look for FSV 5091-5094 in attributes
+    for attr_name, attr_value in indoor.attributes.items():
+        if "5091" in attr_name or "5092" in attr_name or \
+           "5093" in attr_name or "5094" in attr_name:
+            print(f"  {attr_name}: {attr_value}")
+
+    await nasa.stop()
+```
+
+### Setting Smart Grid Mode via Message Sending
+
+```python
+from pysamsungnasa import SamsungNasa
+from pysamsungnasa.protocol.factory.messages.indoor import InSgReadyModeStateMessage
+
+async def set_smart_grid_mode(nasa, target_address, mode):
+    """
+    Set Smart Grid operation mode (1-4).
+
+    This is the recommended approach using write_attribute, which handles
+    all message encoding and transmission internally.
+
+    Args:
+        nasa: SamsungNasa instance
+        target_address: Device address (e.g., "200020" for indoor unit 1)
+        mode: Operation mode (1-4)
+            - 1: Forced thermostat off (emergency load shedding)
+            - 2: Normal operation (user setpoints)
+            - 3: Load increase (pre-heating mode)
+            - 4: Load decrease (demand response mode)
+    """
+    device = nasa.devices.get(target_address)
+    if not device:
+        print(f"Device {target_address} not found")
+        return False
+
+    try:
+        # Use write_attribute for clean, supported API
+        await device.write_attribute(InSgReadyModeStateMessage, mode)
+        print(f"Set device {target_address} to Mode {mode}")
+        return True
+    except Exception as e:
+        print(f"Failed to set mode: {e}")
+        return False
+
+async def enable_smart_grid(nasa, target_address):
+    """Enable FSV #5091 (Smart Grid Control Application)"""
+    from pysamsungnasa.protocol.factory.messages.indoor import InFsv5091Message
+
+    device = nasa.devices.get(target_address)
+    if not device:
+        return False
+
+    try:
+        await device.write_attribute(InFsv5091Message, 1)  # 1 = enabled
+        print(f"Enabled Smart Grid Control on {target_address}")
+        return True
+    except Exception as e:
+        print(f"Failed to enable smart grid: {e}")
+        return False
+
+async def configure_smart_grid_response(
+    nasa,
+    target_address,
+    heating_shift=2.0,  # FSV #5092 in °C
+    dhw_shift=5.0,      # FSV #5093 in °C
+    dhw_mode=0          # FSV #5094: 0=Comfort, 1=Demand Response
+):
+    """
+    Configure how system responds to grid signals.
+
+    Uses write_attribute for all message sending - the recommended approach.
+
+    Args:
+        nasa: SamsungNasa instance
+        target_address: Device address
+        heating_shift: Temperature increase for heating (2-5°C)
+        dhw_shift: Temperature increase for DHW (2-5°C)
+        dhw_mode: 0=Comfort (DHW continues), 1=Demand Response (DHW stops)
+    """
+    from pysamsungnasa.protocol.factory.messages.indoor import (
+        InFsv5092,
+        InFsv5093,
+        InFsv5094Message,
+    )
+
+    device = nasa.devices.get(target_address)
+    if not device:
+        return False
+
+    try:
+        # Configure heating response
+        await device.write_attribute(InFsv5092, heating_shift)
+
+        # Configure DHW pre-heating
+        await device.write_attribute(InFsv5093, dhw_shift)
+
+        # Configure DHW mode priority
+        await device.write_attribute(InFsv5094Message, dhw_mode)
+
+        print(f"Configured smart grid response on {target_address}")
+        return True
+    except Exception as e:
+        print(f"Failed to configure smart grid: {e}")
+        return False
+```
+
+**Important**: Always use `write_attribute()` method for sending messages to devices. The internal `to_bytes()` methods are for framework use only and should not be called directly.
+
+### Monitoring Grid Response Status
+
+```python
+import asyncio
+from pysamsungnasa import SamsungNasa
+
+async def monitor_smart_grid_response():
+    """Monitor how system responds to grid signals"""
+
+    nasa = SamsungNasa(
+        host="192.168.1.100",
+        port=8000,
+        config={"client_address": 1}
+    )
+
+    await nasa.start()
+
+    async def on_device_update(device):
+        """Called whenever device updates"""
+        if device.address == "200020":  # Indoor unit
+            print(f"Smart Grid Status Update:")
+            # Check for operation mode, temperature, status
+            print(f"  Power: {device.climate_controller.power if device.climate_controller else 'N/A'}")
+            print(f"  Mode: {device.climate_controller.current_mode if device.climate_controller else 'N/A'}")
+            print(f"  Temp: {device.climate_controller.f_current_temperature if device.climate_controller else 'N/A'}°C")
+
+    # Register update callback
+    indoor = nasa.devices.get("200020")
+    if indoor:
+        indoor.add_device_callback(on_device_update)
+
+    # Monitor for 1 hour
+    await asyncio.sleep(3600)
+    await nasa.stop()
+
+asyncio.run(monitor_smart_grid_response())
+```
+
+## Troubleshooting
+
+### Smart Grid Mode Not Triggering
+
+1. **Check FSV #5091**: Verify smart grid is enabled (value = 1)
+2. **Verify signal**: Confirm grid signal is being sent to terminals or via Modbus
+3. **Check terminal connections**: Ensure terminals are properly connected and shorts/opens match mode requirements
+4. **Review configuration**: Verify FSV #5092, #5093, #5094 are set correctly
+5. **Check logs**: Enable debug logging to see if messages are being received
+
+### System Not Responding to Mode Changes
+
+1. **Verify messaging**: Confirm Modbus commands are reaching the device
+2. **Check addressing**: Ensure target device address is correct
+3. **Review state**: Some modes may not be available depending on current operation state
+4. **Temperature constraints**: FSV values must be within allowed ranges (2-5°C)
+
+### Unexpected Temperature Changes
+
+1. **Review FSV #5092/5093**: Verify temperature shift values are as intended
+2. **Check current setpoints**: Shifts are relative to current user setpoint
+3. **Monitor FSV #5094**: In demand response mode, DHW may reduce unexpectedly
+4. **Check operation mode**: Temperature behavior differs between Mode 3 and Mode 4
+
+## Related Settings
+
+For comprehensive demand-side management, also consider:
+
+- **FSV #5081**: PV Control Application (solar optimization)
+- **FSV #5082/5083**: PV temperature shifts (solar-aware setpoints)
+- **FSV #5041/5042/5043**: Power Peak Control (simpler load shedding)
+- **FSV #5051**: Frequency Ratio Control (compressor frequency limiting)
+- **FSV #5022**: DHW Saving Mode (energy-saving offset)
+
+## Standards and Regulations
+
+Smart Grid Control implementations support:
+
+- **OpenADR 2.0**: Open Automated Demand Response protocol
+- **Utility Demand Response Programs**: Peak time rebates (PTR), critical peak pricing (CPP)
+- **Local regulations**: Compliant with grid integration requirements in EU, US, and other regions
+- **SG-Ready**: Samsung complies with SG-Ready protocol for heat pump demand response
+
+## See Also
+
+- [Smart Thermostat Example](../examples.md#smart-thermostat)
+- [Configuration Guide](./configuration.md)
+- [Message Reference](../protocol/messages-reference.md)
+- [Protocol Overview](../protocol/overview.md)

--- a/docs/user-guide/smart-grid-control.md
+++ b/docs/user-guide/smart-grid-control.md
@@ -28,7 +28,7 @@ Smart Grid Control operates through four distinct operating modes, controlled ex
 | **3: Load Increase** | Open | Short (0V) | Temperature setpoints raised (+FSV #5092, +FSV #5093) |
 | **4: Load Reduction** | Short (0V) | Short (0V) | Temperature adjusted per FSV #5094 settings |
 
-**Important**: The four modes are controlled via physical terminal connections, NOT via Modbus messages. Message 0x4124 is only used to enable/disable SG Ready mode.
+**Important**: The four modes are controlled via physical terminal connections, NOT via software messages. Message 0x4124 is only used to enable/disable SG Ready mode.
 
 ## Configuration
 
@@ -406,17 +406,10 @@ asyncio.run(monitor_smart_grid_response())
 ### Smart Grid Mode Not Triggering
 
 1. **Check FSV #5091**: Verify smart grid is enabled (value = 1)
-2. **Verify signal**: Confirm grid signal is being sent to terminals or via Modbus
+2. **Verify signal**: Confirm grid signal is being sent to terminals
 3. **Check terminal connections**: Ensure terminals are properly connected and shorts/opens match mode requirements
 4. **Review configuration**: Verify FSV #5092, #5093, #5094 are set correctly
 5. **Check logs**: Enable debug logging to see if messages are being received
-
-### System Not Responding to Mode Changes
-
-1. **Verify messaging**: Confirm Modbus commands are reaching the device
-2. **Check addressing**: Ensure target device address is correct
-3. **Review state**: Some modes may not be available depending on current operation state
-4. **Temperature constraints**: FSV values must be within allowed ranges (2-5°C)
 
 ### Unexpected Temperature Changes
 

--- a/pysamsungnasa/protocol/enum.py
+++ b/pysamsungnasa/protocol/enum.py
@@ -1385,12 +1385,25 @@ class InFsv5094(SamsungEnum, IntEnum):
 class InSgReadyModeState(SamsungEnum, IntEnum):
     """
     SG Ready Mode State (Message 0x4124).
+
+    Controls the Smart Grid Ready operation mode, determining how the heat pump responds to
+    external grid demand signals. Modes are typically controlled via two external terminals
+    (T1/T2) or via Modbus messages. Each mode represents a different grid demand response state.
+
     Label (NASA.prc): ENUM_IN_SG_READY_MODE_STATE
     XML ProtocolID: ENUM_IN_SG_READY_MODE_STATE
-    Values not defined in NASA.ptc
     """
 
-    pass
+    DISABLED = 0
+    """SG Disabled"""
+    NORMAL = 1
+    """Normal operation - No grid signal active, system operates based on heating/DHW demand"""
+    BOOST = 2
+    """Increased power demand - Grid signal requesting increased load, heating boost active"""
+    LOAD_REDUCTION = 3
+    """Reduced power demand (grid peak) - Grid signal requesting reduced load, heating/DHW limited"""
+    EMERGENCY_SHUTDOWN = 4
+    """Forced stop/emergency - Grid signal requesting shutdown, all heating/DHW components forced off"""
 
 
 class NmNetworkPositionLayer(SamsungEnum, IntEnum):

--- a/pysamsungnasa/protocol/enum.py
+++ b/pysamsungnasa/protocol/enum.py
@@ -1386,24 +1386,21 @@ class InSgReadyModeState(SamsungEnum, IntEnum):
     """
     SG Ready Mode State (Message 0x4124).
 
-    Controls the Smart Grid Ready operation mode, determining how the heat pump responds to
-    external grid demand signals. Modes are typically controlled via two external terminals
-    (T1/T2) or via Modbus messages. Each mode represents a different grid demand response state.
+    Enables/disables Smart Grid Ready mode for the heat pump system. When enabled, the system
+    can respond to external grid demand signals via physical terminal inputs (Terminal 1 & 2)
+    or through compatible control systems.
+
+    Note: The four Smart Grid operation modes (1-4) are controlled via terminal configurations,
+    not via this message. See the Smart Grid Control user guide for terminal connection details.
 
     Label (NASA.prc): ENUM_IN_SG_READY_MODE_STATE
     XML ProtocolID: ENUM_IN_SG_READY_MODE_STATE
     """
 
-    DISABLED = 0
-    """SG Disabled"""
-    NORMAL = 1
-    """Normal operation - No grid signal active, system operates based on heating/DHW demand"""
-    BOOST = 2
-    """Increased power demand - Grid signal requesting increased load, heating boost active"""
-    LOAD_REDUCTION = 3
-    """Reduced power demand (grid peak) - Grid signal requesting reduced load, heating/DHW limited"""
-    EMERGENCY_SHUTDOWN = 4
-    """Forced stop/emergency - Grid signal requesting shutdown, all heating/DHW components forced off"""
+    OFF = 0
+    """SG Ready mode disabled - system operates independently"""
+    ON = 1
+    """SG Ready mode enabled - system responds to grid demand signals via terminals"""
 
 
 class NmNetworkPositionLayer(SamsungEnum, IntEnum):


### PR DESCRIPTION
Enhance the documentation for Smart Grid Control by adding detailed explanations of message parsing, terminal connections, and operational modes. Update enums for better clarity and remove outdated Modbus references.

This is not tested or validated, some docs point to the state being controllable by software, others state differently.