### PR TITLE
Downgrade serialx dependency version to 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">=3.13.0"
 dynamic = ["version"]
 dependencies = [
-    "serialx>=1.5.0"
+    "serialx>=1.4.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Dependancy is no longer strict and therefore will work with Home Assistant