### PR TITLE
fix: stop retry manager lockup on abandoned writes

### DIFF
--- a/pysamsungnasa/nasa_client.py
+++ b/pysamsungnasa/nasa_client.py
@@ -399,8 +399,8 @@ class NasaClient:
         if self._retry_manager_task and not self._retry_manager_task.done():
             _LOGGER.error("Retry manager task already running.")
             return True
-        if not self._config.enable_read_retries:
-            _LOGGER.debug("Read retries are disabled in config.")
+        if not (self._config.enable_read_retries or self._config.enable_write_retries):
+            _LOGGER.debug("Retries are disabled in config.")
             return False
         self._retry_manager_task = asyncio.create_task(self._retry_manager())
         _LOGGER.debug("Retry manager session started.")
@@ -623,9 +623,11 @@ class NasaClient:
             if packet_number is not None:
                 current_time = asyncio.get_running_loop().time()
                 if request_type in (DataType.WRITE, DataType.REQUEST) and self._config.enable_write_retries:
-                    # Track all messages in the packet together using packet_number as key
+                    # Track all messages in the packet together using a stable
+                    # dest+message_ids key so retries (which allocate a new packet
+                    # number) update the same entry instead of creating duplicates.
                     message_ids = [msg.MESSAGE_ID for msg in messages]
-                    write_key = f"{destination_address}_{packet_number}"
+                    write_key = f"{destination_address}_{tuple(sorted(message_ids))}"
                     existing_write = self._pending_writes.get(write_key)
                     if existing_write is None:
                         self._pending_writes[write_key] = {
@@ -760,14 +762,28 @@ class NasaClient:
             )
 
     def _clear_pending_read(self, destination: str, message_numbers: list[int]) -> bool:
-        """Clear a pending read request when a response is received with matching message numbers."""
-        # Create a key from the sorted message numbers, same as when we track the request
-        read_key = f"{destination}_{tuple(sorted(message_numbers))}"
-        if read_key in self._pending_reads:
-            del self._pending_reads[read_key]
-            _LOGGER.debug("Cleared pending read request for messages %s from %s", message_numbers, destination)
-            return True
-        return False
+        """Clear pending read requests when a response contains the requested messages.
+
+        A response may include extra message IDs beyond those requested. Clear any
+        pending read whose requested IDs are a subset of the response.
+        """
+        if not message_numbers:
+            return False
+
+        keys_to_delete = []
+        response_ids = set(message_numbers)
+        for read_key, read_info in self._pending_reads.items():
+            if read_info["destination"] != destination:
+                continue
+            requested = set(read_info.get("messages", []))
+            if requested and requested.issubset(response_ids):
+                keys_to_delete.append(read_key)
+
+        for key in keys_to_delete:
+            del self._pending_reads[key]
+            _LOGGER.debug("Cleared pending read request for key %s from %s", key, destination)
+
+        return bool(keys_to_delete)
 
     async def _mark_read_received(self, destination: str, message_numbers: list[int]) -> None:
         """Mark a read/write request as received (event callback from parser).
@@ -880,21 +896,32 @@ class NasaClient:
                     writes_to_retry = []
                     writes_to_remove = []
 
-                    # Identify writes that need to be retried
+                    # Identify writes that need to be retried.
+                    # Inspect each entry independently so a single bad record cannot
+                    # abort the loop (which previously left abandoned writes in place
+                    # and re-raised KeyError every second).
                     for write_key, write_info in list(self._pending_writes.items()):
-                        if current_time >= write_info["next_retry_time"]:
+                        try:
+                            if current_time < write_info["next_retry_time"]:
+                                continue
                             if write_info["attempts"] < self._config.write_retry_max_attempts:
                                 writes_to_retry.append((write_key, write_info))
                             else:
                                 # Max retries exceeded
                                 _LOGGER.warning(
-                                    "Abandoning write request %s (message %s) to %s after %d attempts",
-                                    write_info["packet_number"],
-                                    write_info["message_id"],
-                                    write_info["destination"],
-                                    write_info["attempts"],
+                                    "Abandoning write request %s (messages %s) to %s after %d attempts",
+                                    write_info.get("packet_number"),
+                                    write_info.get("message_ids"),
+                                    write_info.get("destination"),
+                                    write_info.get("attempts"),
                                 )
                                 writes_to_remove.append(write_key)
+                        except Exception:
+                            _LOGGER.exception(
+                                "Error inspecting pending write %s; dropping it to avoid retry-manager stall",
+                                write_key,
+                            )
+                            writes_to_remove.append(write_key)
 
                     # Remove writes that have exceeded max attempts
                     for write_key in writes_to_remove:

--- a/pysamsungnasa/protocol/factory/messages/basic.py
+++ b/pysamsungnasa/protocol/factory/messages/basic.py
@@ -63,9 +63,16 @@ class SerialNumber(StructureMessage):
     @classmethod
     def parse_payload(cls, payload: bytes) -> "SerialNumber":
         """Parse the payload into a string."""
-        # Convert the payload bytes to ASCII string, stripping null bytes
-        ascii_string = payload.decode("ascii").rstrip("\x00")
-        return cls(value=ascii_string, raw_payload=payload)
+        if not payload:
+            return cls(value="", raw_payload=payload)
+        # NASA uses all-0xFF as "not available" on unused/unsupported fields
+        if payload == b"\xff" * len(payload):
+            return cls(value=None, raw_payload=payload)
+        try:
+            ascii_string = payload.decode("ascii").rstrip("\x00")
+            return cls(value=ascii_string, raw_payload=payload)
+        except UnicodeDecodeError:
+            return cls(value=None, raw_payload=payload)
 
 
 def format_db_code(payload: bytes) -> str | None:

--- a/tests/test_factory_extended.py
+++ b/tests/test_factory_extended.py
@@ -463,6 +463,22 @@ class TestBasicMessages:
 
         assert result.VALUE == "TEST"
 
+    def test_serial_number_unavailable_ff_payload(self):
+        """All-0xFF payloads are the NASA unavailable sentinel, not ASCII text."""
+        payload = b"\xff" * 16
+        result = SerialNumber.parse_payload(payload)
+
+        assert result.VALUE is None
+        assert result.RAW_PAYLOAD == payload
+
+    def test_serial_number_non_ascii_payload(self):
+        """Non-ASCII payloads should not raise UnicodeDecodeError."""
+        payload = b"\xff\xfe\xfd"
+        result = SerialNumber.parse_payload(payload)
+
+        assert result.VALUE is None
+        assert result.RAW_PAYLOAD == payload
+
     def test_db_code_micom_too_short(self):
         """Test DbCodeMiComMainMessage with too short payload."""
         result = DbCodeMiComMainMessage.parse_payload(b"\x91\x02\x09")

--- a/tests/test_retry_logic.py
+++ b/tests/test_retry_logic.py
@@ -24,8 +24,8 @@ class TestSendMessageRetryTracking:
             )
 
             # Check that the write was tracked
-            # Note: Keys are formatted as destination_packet_number
-            write_key = "200001_1"  # packet_number=1
+            # Keys are destination + sorted message IDs so retries keep the same entry
+            write_key = "200001_(16384,)"  # 0x4000
             assert write_key in client._pending_writes
             write_info = client._pending_writes[write_key]
             assert write_info["destination"] == "200001"
@@ -71,7 +71,7 @@ class TestSendMessageRetryTracking:
             )
 
             # REQUEST type should be tracked as write retry
-            write_key = "100001_3"  # 0x5000 = 20480
+            write_key = "100001_(20480,)"  # 0x5000 = 20480
             assert write_key in client._pending_writes
 
     @pytest.mark.asyncio
@@ -113,8 +113,8 @@ class TestSendMessageRetryTracking:
                 messages=messages,
             )
 
-            # All messages in one packet should have a single entry with packet_number key
-            write_key = "200001_5"  # packet_number=5
+            # All messages in one packet should have a single entry keyed by dest + message IDs
+            write_key = "200001_(16384, 16385, 16386)"  # 0x4000, 0x4001, 0x4002
             assert write_key in client._pending_writes
             write_info = client._pending_writes[write_key]
             assert write_info["message_ids"] == [0x4000, 0x4001, 0x4002]
@@ -162,9 +162,9 @@ class TestSendMessageRetryTracking:
         """Test that re-sending an already tracked write does not reset retry state."""
         client = nasa_client
         messages = [SendMessage(MESSAGE_ID=0x4000, PAYLOAD=b"\x01")]
-        write_key = "200001_7"
+        write_key = "200001_(16384,)"
 
-        # Use same packet number to hit existing write entry
+        # Initial send creates tracked write
         with patch.object(client, "send_command", new_callable=AsyncMock, return_value=7):
             await client.send_message(
                 destination="200001",
@@ -177,19 +177,21 @@ class TestSendMessageRetryTracking:
         client._pending_writes[write_key]["retry_interval"] = 1.1
         old_next_retry_time = client._pending_writes[write_key]["next_retry_time"]
 
-        # Resend should refresh metadata but not reset attempts/backoff
-        with patch.object(client, "send_command", new_callable=AsyncMock, return_value=7):
+        # Resend with a new packet number (as send_command does in production)
+        # must update the same entry rather than creating a duplicate.
+        with patch.object(client, "send_command", new_callable=AsyncMock, return_value=8):
             await client.send_message(
                 destination="200001",
                 request_type=DataType.WRITE,
                 messages=messages,
             )
 
+        assert list(client._pending_writes) == [write_key]
         write_info = client._pending_writes[write_key]
         assert write_info["attempts"] == 1
         assert write_info["retry_interval"] == 1.1
         assert write_info["next_retry_time"] == old_next_retry_time
-        assert write_info["packet_number"] == 7
+        assert write_info["packet_number"] == 8
 
 
 class TestNasaWriteRetry:
@@ -208,7 +210,7 @@ class TestNasaWriteRetry:
             )
 
             # Check that write was tracked with message_ids and messages
-            write_key = "200001_1"  # packet_number=1
+            write_key = "200001_(16384,)"  # 0x4000
             assert write_key in client._pending_writes
             write_info = client._pending_writes[write_key]
             assert write_info["message_ids"] == [0x4000]
@@ -348,8 +350,8 @@ class TestRetryManagerRetryBehavior:
         initial_interval = 0.1
         client._pending_writes[write_key] = {
             "destination": "200001",
-            "message_id": 0x4000,
-            "payload": b"\x01",
+            "message_ids": [0x4000],
+            "messages": [SendMessage(MESSAGE_ID=0x4000, PAYLOAD=b"\x01")],
             "data_type": DataType.WRITE,
             "packet_number": 1,
             "attempts": 0,
@@ -398,8 +400,8 @@ class TestRetryManagerRetryBehavior:
 
         client._pending_writes[write_key] = {
             "destination": "200001",
-            "message_id": 0x4000,
-            "payload": b"\x01",
+            "message_ids": [0x4000],
+            "messages": [SendMessage(MESSAGE_ID=0x4000, PAYLOAD=b"\x01")],
             "data_type": DataType.WRITE,
             "packet_number": 1,
             "attempts": client._config.write_retry_max_attempts,  # Already at max
@@ -432,6 +434,151 @@ class TestRetryManagerRetryBehavior:
                 mock_send.assert_not_called()
                 # And the pending write should be removed
                 assert write_key not in client._pending_writes
+
+    @pytest.mark.asyncio
+    async def test_retry_manager_abandons_legacy_message_id_entry(self, nasa_client_with_full_retry_config):
+        """Abandoned writes must be dropped even if they use the legacy message_id key.
+
+        A KeyError on write_info['message_id'] previously aborted the retry loop
+        every second and left the entry in place, stalling further retries.
+        """
+        client = nasa_client_with_full_retry_config
+        current_time = asyncio.get_running_loop().time()
+        client._pending_writes.clear()
+        client._pending_reads.clear()
+
+        stale_key = "stale_200001_1"
+        healthy_key = "healthy_200002_(16384,)"
+        messages = [SendMessage(MESSAGE_ID=0x4000, PAYLOAD=b"\x01")]
+        client._pending_writes[stale_key] = {
+            "destination": "200001",
+            "message_id": 0x4000,  # legacy schema used by older tracking
+            "payload": b"\x01",
+            "data_type": DataType.WRITE,
+            "packet_number": 1,
+            "attempts": client._config.write_retry_max_attempts,
+            "last_attempt_time": current_time,
+            "next_retry_time": current_time - 1.0,
+            "retry_interval": 0.1,
+        }
+        client._pending_writes[healthy_key] = {
+            "destination": "200002",
+            "message_ids": [0x4000],
+            "messages": messages,
+            "data_type": DataType.WRITE,
+            "packet_number": 2,
+            "attempts": 0,
+            "last_attempt_time": current_time,
+            "next_retry_time": current_time - 1.0,
+            "retry_interval": 0.1,
+        }
+
+        retry_send_call_count = 0
+
+        async def mock_send(*args, **kwargs):
+            nonlocal retry_send_call_count
+            retry_send_call_count += 1
+            return None
+
+        sleep_count = 0
+
+        async def mock_sleep(delay):
+            nonlocal sleep_count
+            sleep_count += 1
+            if sleep_count == 1:
+                return
+            raise asyncio.CancelledError()
+
+        with patch.object(client, "send_message", new_callable=AsyncMock, side_effect=mock_send):
+            with patch("asyncio.sleep", side_effect=mock_sleep):
+                retry_task = asyncio.create_task(client._retry_manager())
+                try:
+                    await retry_task
+                except asyncio.CancelledError:
+                    pass
+
+        assert stale_key not in client._pending_writes
+        assert retry_send_call_count > 0
+        assert healthy_key in client._pending_writes
+        assert client._pending_writes[healthy_key]["attempts"] == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_manager_drops_corrupt_pending_write(self, nasa_client_with_full_retry_config):
+        """Corrupt pending-write records must be dropped without stalling the loop."""
+        client = nasa_client_with_full_retry_config
+        current_time = asyncio.get_running_loop().time()
+        client._pending_writes.clear()
+        client._pending_reads.clear()
+
+        corrupt_key = "corrupt_200001"
+        healthy_key = "healthy_200002_(16384,)"
+        client._pending_writes[corrupt_key] = {"destination": "200001"}  # missing retry fields
+        client._pending_writes[healthy_key] = {
+            "destination": "200002",
+            "message_ids": [0x4000],
+            "messages": [SendMessage(MESSAGE_ID=0x4000, PAYLOAD=b"\x01")],
+            "data_type": DataType.WRITE,
+            "packet_number": 2,
+            "attempts": 0,
+            "last_attempt_time": current_time,
+            "next_retry_time": current_time - 1.0,
+            "retry_interval": 0.1,
+        }
+
+        retry_send_call_count = 0
+
+        async def mock_send(*args, **kwargs):
+            nonlocal retry_send_call_count
+            retry_send_call_count += 1
+            return None
+
+        sleep_count = 0
+
+        async def mock_sleep(delay):
+            nonlocal sleep_count
+            sleep_count += 1
+            if sleep_count == 1:
+                return
+            raise asyncio.CancelledError()
+
+        with patch.object(client, "send_message", new_callable=AsyncMock, side_effect=mock_send):
+            with patch("asyncio.sleep", side_effect=mock_sleep):
+                retry_task = asyncio.create_task(client._retry_manager())
+                try:
+                    await retry_task
+                except asyncio.CancelledError:
+                    pass
+
+        assert corrupt_key not in client._pending_writes
+        assert retry_send_call_count > 0
+
+
+class TestRetryManagerSession:
+    """Tests for starting the retry manager task."""
+
+    @pytest.mark.asyncio
+    async def test_starts_when_only_write_retries_enabled(self, nasa_client_write_only):
+        """Write-only retry config must still start the retry manager."""
+        client = nasa_client_write_only
+        started = await client._start_retry_manager_session()
+        try:
+            assert started is True
+            assert client._retry_manager_task is not None
+            assert not client._retry_manager_task.done()
+            # Starting again should be a no-op success
+            assert await client._start_retry_manager_session() is True
+        finally:
+            await client._end_retry_manager_session()
+
+    @pytest.mark.asyncio
+    async def test_does_not_start_when_retries_disabled(self, nasa_client):
+        """Retry manager should not start when both retry flags are off."""
+        client = nasa_client
+        client._config.enable_read_retries = False
+        client._config.enable_write_retries = False
+        started = await client._start_retry_manager_session()
+        assert started is False
+        assert client._retry_manager_task is None
 
 
 class TestWriteAttributesWithRetry:
@@ -478,14 +625,12 @@ class TestRetryStateManagement:
     """Tests for proper state management of retry logic."""
 
     def test_write_key_format(self):
-        """Test that write keys are properly formatted."""
-        # The write key should be destination_packet_number
+        """Test that write keys are dest + sorted message IDs, matching reads."""
         dest = "200001"
-        packet_number = 1
+        msgs = [0x4001, 0x4000]
 
-        # Write keys now use packet_number to group all messages in a packet
-        write_key = f"{dest}_{packet_number}"
-        assert write_key == "200001_1"
+        write_key = f"{dest}_{tuple(sorted(msgs))}"
+        assert write_key == "200001_(16384, 16385)"
 
     def test_read_key_format(self):
         """Test that read keys use sorted tuple of message IDs."""
@@ -504,8 +649,7 @@ class TestRetryStateManagement:
 
         write_info = {
             "destination": "200001",
-            "message_id": 0x4000,
-            "payload": b"\x01",
+            "message_ids": [0x4000],
             "data_type": DataType.WRITE,
             "packet_number": 1,
             "attempts": 0,
@@ -734,3 +878,109 @@ class TestAckClearing:
 
         # Should still be cleared
         assert "200001_1" not in client._pending_writes
+
+
+class TestReadClearing:
+    """Tests for clearing pending reads when a response is received."""
+
+    async def test_exact_message_ids_clear_pending_read(self, nasa_client):
+        """Test that a response with the exact requested IDs clears the pending read."""
+        client = nasa_client
+        read_key = "200001_(16384, 16385)"
+        client._pending_reads[read_key] = {
+            "destination": "200001",
+            "messages": [0x4000, 0x4001],
+            "packet_number": 1,
+            "attempts": 0,
+            "last_attempt_time": 0,
+            "next_retry_time": 0,
+            "retry_interval": 0.1,
+        }
+
+        assert client._clear_pending_read("200001", [0x4000, 0x4001])
+        assert read_key not in client._pending_reads
+
+    async def test_extra_message_ids_still_clear_pending_read(self, nasa_client):
+        """Test that extra IDs in a response still clear the matching pending read."""
+        client = nasa_client
+        read_key = "200001_(16384,)"
+        client._pending_reads[read_key] = {
+            "destination": "200001",
+            "messages": [0x4000],
+            "packet_number": 1,
+            "attempts": 0,
+            "last_attempt_time": 0,
+            "next_retry_time": 0,
+            "retry_interval": 0.1,
+        }
+
+        assert client._clear_pending_read("200001", [0x4000, 0x4001, 0x9999])
+        assert read_key not in client._pending_reads
+
+    async def test_partial_response_does_not_clear_pending_read(self, nasa_client):
+        """Test that a subset of requested IDs does not clear the pending read."""
+        client = nasa_client
+        read_key = "200001_(16384, 16385)"
+        client._pending_reads[read_key] = {
+            "destination": "200001",
+            "messages": [0x4000, 0x4001],
+            "packet_number": 1,
+            "attempts": 0,
+            "last_attempt_time": 0,
+            "next_retry_time": 0,
+            "retry_interval": 0.1,
+        }
+
+        assert not client._clear_pending_read("200001", [0x4000])
+        assert read_key in client._pending_reads
+
+    async def test_empty_message_numbers_do_not_clear_pending_read(self, nasa_client):
+        """Empty ACK-style message lists should not clear pending reads."""
+        client = nasa_client
+        read_key = "200001_(16384,)"
+        client._pending_reads[read_key] = {
+            "destination": "200001",
+            "messages": [0x4000],
+            "packet_number": 1,
+            "attempts": 0,
+            "last_attempt_time": 0,
+            "next_retry_time": 0,
+            "retry_interval": 0.1,
+        }
+
+        assert not client._clear_pending_read("200001", [])
+        assert read_key in client._pending_reads
+
+    async def test_empty_requested_ids_do_not_clear_pending_read(self, nasa_client):
+        """A tracked read with no message IDs should not be cleared by an unrelated response."""
+        client = nasa_client
+        read_key = "200001_()"
+        client._pending_reads[read_key] = {
+            "destination": "200001",
+            "messages": [],
+            "packet_number": 1,
+            "attempts": 0,
+            "last_attempt_time": 0,
+            "next_retry_time": 0,
+            "retry_interval": 0.1,
+        }
+
+        assert not client._clear_pending_read("200001", [0x4000])
+        assert read_key in client._pending_reads
+
+    async def test_response_for_other_destination_does_not_clear(self, nasa_client):
+        """Responses from a different device must not clear this device's pending read."""
+        client = nasa_client
+        read_key = "200001_(16384,)"
+        client._pending_reads[read_key] = {
+            "destination": "200001",
+            "messages": [0x4000],
+            "packet_number": 1,
+            "attempts": 0,
+            "last_attempt_time": 0,
+            "next_retry_time": 0,
+            "retry_interval": 0.1,
+        }
+
+        assert not client._clear_pending_read("100000", [0x4000])
+        assert read_key in client._pending_reads


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

When a write hit `write_retry_max_attempts`, `_retry_manager` logged:

```python
write_info["message_id"]
```

Pending writes are stored under `message_ids` (plural) after the multi-message packet tracking change. The resulting `KeyError` was caught by the outer `except Exception` in the retry loop, so:

1. The abandoned write was **never removed** from `_pending_writes`
2. The same exception fired **every second** (matching ~9499 occurrences over ~2.6 hours)
3. The rest of that iteration’s write handling was skipped, so other writes could not be retried or abandoned
4. Home Assistant then reported `pysamsungnasa.nasa_client is logging too frequently`

That is the lockup: the retry manager keeps running, but write retry/abandon is stuck, and the log flood drowns the rest of the integration.

## Related issues (same logs)

**Write retries creating duplicate pending entries.** Writes were keyed by `destination_packet_number`. Each retry allocates a new packet number, so `send_message` created a *new* pending write with `attempts=0` instead of updating the existing one. The “preserve retry state on resend” branch never ran in production.

**Serial number `0xFF` payloads.** Message `1543` (`0x0607`) with payload `ffffffffffffffffffffffffffffffff` is the NASA “unavailable” sentinel, not ASCII. `SerialNumber.parse_payload` did `payload.decode("ascii")` and raised `UnicodeDecodeError`. Parsing continued via the `RawMessage` fallback, but it spammed errors. This did not stall the bus; it is fixed for robustness.

**Invalid CRC / abandoned reads.** CRC failures correctly drop the packet, so the matching read never clears and is abandoned after 3 attempts. Some of that is bus noise; write-retry duplication can also increase collisions on a half-duplex RS485 bus. Pending reads now clear when the response *contains* the requested IDs (extra IDs no longer keep the read outstanding).

## Fixes

- Log and abandon writes using `message_ids`; inspect each pending write independently and drop corrupt records instead of stalling the loop
- Key pending writes by destination + sorted message IDs so retries with a new packet number update the same entry
- Start the retry manager when **either** read or write retries are enabled
- Treat all-`0xFF` / non-ASCII serial number payloads as unavailable (`None`)
- Clear pending reads when requested IDs are a subset of the response

## Tests

- Regression: abandoning a write with the production `message_ids` schema removes it
- Legacy `message_id` / corrupt entries are dropped without blocking other retries
- Write resend with a new packet number preserves retry state and does not duplicate entries
- Serial number `0xFF` and non-ASCII payloads do not raise
- Pending reads clear on superset responses, not on partial/empty/wrong-destination responses

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7c70dbc-582d-4ff9-b7a6-edf10fd63daa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7c70dbc-582d-4ff9-b7a6-edf10fd63daa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

